### PR TITLE
Fix SIGSEGV in S3StorageInteractor.ListPath.

### DIFF
--- a/pkg/proc/interaction.go
+++ b/pkg/proc/interaction.go
@@ -121,7 +121,7 @@ func ProcessPutExtended(
 					return
 				} else if n != int(msg.Sz) {
 
-					_ = ycl.ReplyError(fmt.Errorf("unfull write"), "failed to compelete request")
+					_ = ycl.ReplyError(fmt.Errorf("unfull write"), "failed to complete request")
 
 					return
 				}
@@ -177,7 +177,7 @@ func ProcessListExtended(msg message.ListMessage, s storage.StorageInteractor, c
 
 	objectMetas, err := s.ListPath(msg.Prefix)
 	if err != nil {
-		_ = ycl.ReplyError(fmt.Errorf("could not list objects: %s", err), "failed to compelete request")
+		_ = ycl.ReplyError(fmt.Errorf("could not list objects: %s", err), "failed to complete request")
 
 		return nil
 	}

--- a/pkg/storage/s3storage.go
+++ b/pkg/storage/s3storage.go
@@ -166,6 +166,7 @@ func (s *S3StorageInteractor) ListPath(prefix string) ([]*object.ObjectInfo, err
 		out, err := sess.ListObjectsV2(input)
 		if err != nil {
 			fmt.Printf("list error: %v\n", err)
+			return nil, err
 		}
 
 		for _, obj := range out.Contents {


### PR DESCRIPTION
When source S3 bucket have been deleted we receive SignatureDoesNotMatch error when trying to list objects in bucket. This error wasn't handled properly, so it lead to nil-reference dereference in next line:
```
list error: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
        status code: 403, request id: <edited>, host id:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb60386]
goroutine 40 [running]:
github.com/yezzey-gp/yproxy/pkg/storage.(*S3StorageInteractor).ListPath(0xc0004a2330, {0xc00003cc00, 0x2a})
        /root/build/yproxy/pkg/storage/s3storage.go:153 +0x2a6
github.com/yezzey-gp/yproxy/pkg/proc.ProcConn({0x10c9da0?, 0xc0004a2840}, {0x10c1f28?, 0xc0004921c0}, {0x10cb598, 0xc0004a2000})
        /root/build/yproxy/pkg/proc/interaction.go:286 +0xe62
github.com/yezzey-gp/yproxy/pkg/core.(*Instance).Run.func3({0x10cb820?, 0xc000066068})
        /root/build/yproxy/pkg/core/core.go:137 +0x147
created by github.com/yezzey-gp/yproxy/pkg/core.(*Instance).DispatchServer.func1 in goroutine 7
        /root/build/yproxy/pkg/core/core.go:44 +0x198
```

Also, yp-client showed `failed to read params: EOF` to client.


*With this patch:*
Server: no errors
Client: Error: message too big 7377293578888028276
